### PR TITLE
fix docker + tar permissions error 

### DIFF
--- a/bin/opm
+++ b/bin/opm
@@ -1345,7 +1345,7 @@ sub install_target ($$) {
         shell "rm -rf '$dist_dir'";
     }
 
-    shell "tar -xzf '$dist_file'";
+    shell "tar --no-same-owner -xzf '$dist_file'";
 
     if (!-d $dist_dir) {
         err "the unpacked directory $dist_dir not found under $cache_subdir.\n";

--- a/bin/opm
+++ b/bin/opm
@@ -1345,7 +1345,7 @@ sub install_target ($$) {
         shell "rm -rf '$dist_dir'";
     }
 
-    shell "tar --no-same-owner -xzf '$dist_file'";
+    shell "tar -oxzf '$dist_file'";
 
     if (!-d $dist_dir) {
         err "the unpacked directory $dist_dir not found under $cache_subdir.\n";


### PR DESCRIPTION
I ran into the following error running OPM on docker:
```
bash-4.2# opm get openresty/lua-resty-string
* Fetching openresty/lua-resty-string
  Downloading https://opm.openresty.org/api/pkg/tarball/openresty/lua-resty-string-0.09.opm.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6163  100  6163    0     0   4887      0  0:00:01  0:00:01 --:--:--  4887
tar: lua-resty-string-0.09.opm/resty.index: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/sha256.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/sha.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/sha224.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/sha512.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/aes.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/sha384.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/sha1.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/string.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/md5.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty/random.lua: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib/resty: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/lib: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/README.markdown: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/pod/lua-resty-string-0.09/lua-resty-string-0.09.pod: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/pod/lua-resty-string-0.09: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/pod: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm/dist.ini: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: lua-resty-string-0.09.opm: Cannot change ownership to uid 99, gid 99: Operation not permitted
tar: Exiting with failure status due to previous errors
ERROR: failed to run command tar -xzf 'lua-resty-string-0.09.opm.tar.gz'
```

This patch fixes the error by just adding the `--no-same-owner` switch to the tar command.