### PR TITLE
first attempt at supporting `opm build-install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ Commands:
     build               Build from the current working directory a package tarball ready
                         for uploading to the server.
 
+    build-install       Build from the current working directory a package tarball ready
+                        for uploading to the server, verify the build with `server-build`,
+                        and finally install the package locally -- all without
+                        communicating with the server.
+
     clean ARGUMENT...   Do clean-up work. Currently the valid argument is "dist", which
                         cleans up the temporary files and directories created by the "build"
                         command.
@@ -245,7 +250,8 @@ Author Workflow
 
 The package author should put a meta-data file named `dist.ini` on the top-level of the Lua library source tree.
 This file is used by the `opm build` command to build and package up your library into a tarball file which can be
-later uploaded to the central package server via the `opm upload` command.
+later uploaded to the central package server via the `opm upload` command. During development, the author can use
+the `opm build-install` functionality to test the installation process locally.
 
 One example `dist.ini` file looks like below for OpenResty's
 [lua-resty-core](https://github.com/openresty/lua-resty-core) library:

--- a/bin/opm
+++ b/bin/opm
@@ -173,31 +173,30 @@ sub do_get {
 
     #warn Dumper($deps);
 
-    my $ctx = init_installation_ctx(0);
+    my $ctx = init_installation_ctx(0);  # 0 = do not `$upgrade`
 
     for my $dep (@$deps) {
         install_target($ctx, $dep);
     }
 }
 
-sub do_build ($) {
-=pod
-`do_build($)`
-The first argument indicates the build type
-	0 = build
-	1 = server-build
-=cut
-    my $_build_type = shift;
-    my $server_build = ($_build_type == 1) ? 1 : 0;
 
-    #if ($server_build) { while (1) {} }
+=begin comment
+	`do_build($)`
+	The first argument indicates the build type should be a server build
+	`$is_server_build` should just be a "truthy" value (1 vs 0)
+=end comment
+=cut
+
+sub do_build ($) {
+    my $is_server_build = shift;
 
     if (!defined $LuaJIT) {
         $LuaJIT = find_luajit();
     }
 
     my $account;
-    if (!$server_build) {
+    if (!$is_server_build) {
         my ($rc_file, $rc_data) = get_rc_file();
         my $rc_default_sec = $rc_data->{default};
         $account = delete $rc_default_sec->{github_account};
@@ -216,7 +215,7 @@ The first argument indicates the build type
     my $dist_name = delete $ini_default_sec->{name};
     is_valid_dist_name($dist_name, $dist_file);
 
-    if ($server_build) {
+    if ($is_server_build) {
         $account = delete $ini_default_sec->{account}
             or err "$dist_file: key \"account\" not found in the default section.\n";
     }
@@ -312,7 +311,7 @@ The first argument indicates the build type
 
 =begin comment
 
-    if (!$server_build) {
+    if (!$is_server_build) {
         my $out = `curl -sS -I $repo_link 2>&1`;
         if ($out =~ m{^ HTTP/1\.\d \s+ (\d+) \b}ix) {
             my $status = $1;
@@ -331,7 +330,7 @@ The first argument indicates the build type
 
     my $version = delete $ini_default_sec->{version};
 
-    if ($server_build && !$version) {
+    if ($is_server_build && !$version) {
             err "$dist_file: \"version\" field not defined in the default section.\n";
     }
 
@@ -351,8 +350,8 @@ The first argument indicates the build type
             err "$dist_file: requires: too many dependencies: $ndeps\n";
         }
 
-        if (!$server_build) {
-            my $ctx = init_installation_ctx(0);
+        if (!$is_server_build) {
+            my $ctx = init_installation_ctx(0);  # 0 = do not `$upgrade`
             $ctx->{level} = 1;
 
             for my $dep (@$deps) {
@@ -377,7 +376,7 @@ The first argument indicates the build type
 
     my $lib_dir = delete $ini_default_sec->{lib_dir};
 
-    if ($server_build && $lib_dir ne 'lib') {
+    if ($is_server_build && $lib_dir ne 'lib') {
         err "$dist_file: \"lib_dir\" must be \"lib\".\n";
     }
 
@@ -499,7 +498,7 @@ The first argument indicates the build type
 
     my $doc_dir = delete $ini_default_sec->{doc_dir};
 
-    if ($server_build && $doc_dir ne 'lib') {
+    if ($is_server_build && $doc_dir ne 'lib') {
         err "$dist_file: \"doc_dir\" must be \"lib\".\n";
     }
 
@@ -515,7 +514,7 @@ The first argument indicates the build type
 
     my $root_dir = "$dist_name-$version";
 
-    if ($server_build) {
+    if ($is_server_build) {
         $root_dir .= ".opm";
     }
 
@@ -526,7 +525,7 @@ The first argument indicates the build type
     my $dst_lib_dir = File::Spec->catfile($root_dir, "lib");
     make_path($dst_lib_dir);
 
-    if ($server_build) {
+    if ($is_server_build) {
         my $restydoc_index = find_restydoc_index();
         shell "$restydoc_index --outdir '$root_dir' .";
     }
@@ -586,7 +585,7 @@ The first argument indicates the build type
         #warn "$fname => $File::Find::name";
     } },  $doc_dir);
 
-    if (!$server_build) {
+    if (!$is_server_build) {
         my $dst_doc_dir = File::Spec->catfile($root_dir, "lib");
         make_path($dst_doc_dir);
 
@@ -673,75 +672,78 @@ _EOC_
     $TarBall = "$root_dir.tar.gz";
     shell "tar -cvzf '$TarBall' '$root_dir'";
 
-    #if ($server_build) {
+    #if ($is_server_build) {
     #err "something bad bad bad.\n";
     #}
 
     warn "build successful: '$TarBall'\n";
 }
 
-sub do_build_install () {
-=pod
+
+=begin comment
 `do_build_install()`
-This builds the currently authored package, then installs it locally (without 
+This builds the currently authored package, then installs it locally (without
 communicated with the opm server).
 
 It performs these functions:
-
-	opm build
-	cd $dist_name-$version/
-	opm server-build
-	install $dist_name-$version.opm.tar.gz  # psuedocode
+    opm build
+    cd $dist_name-$version/
+    opm server-build
+    install $dist_name-$version.opm.tar.gz  # psuedocode
+=end comment
 =cut
+sub do_build_install () {
+    # phase 1 - `opm build`
+    do_build(0);  # 0 = normal
 
-	# phase 1 - `opm build`
-	do_build(0);  # 0 = normal
-
-	# phase 2 - `cd $dist_name-$version/`
-	# phase 2a - derive the version data	
+    # phase 2 - `cd $dist_name-$version/`
+    # phase 2a - derive the version data
     my $dist_file = "dist.ini";
     my $data = read_ini($dist_file);
     my $default_sec = $data->{default};
     my $dist_name = $default_sec->{name};
     my $version = $default_sec->{version};
 
-	# phase 2b - `cd `
-	my $versioned_directory = "$dist_name-$version";
-	chdir $versioned_directory;
+    # phase 2b - `cd `
+    my $versioned_directory = "$dist_name-$version";
+    chdir $versioned_directory;
 
-	# phase 3 - `opm server-build`
-	shell "opm server-build";
+    # phase 3 - `opm server-build`
+    shell "opm server-build";
 
-	# phase 4 - `install $dist_name-$version.opm.tar.gz`
-	# we're down a directory, go back up
-	# actually, don't.  the opm.gz file is what we want to install here
-	# chdir File::Spec->updir;
+    # phase 4 - `install $dist_name-$version.opm.tar.gz`
+    # we're down a directory, go back up
+    # actually, don't.  the opm.gz file is what we want to install here
+    # chdir File::Spec->updir;
 
-	my $versioned_file = "$dist_name-$version.opm.tar.gz";
+    my $versioned_file = "$dist_name-$version.opm.tar.gz";
 
-	# we need the account info
-	my ($rc_file, $rc_data) = get_rc_file();
-	my $account = $rc_data->{default}->{github_account};
-	if (!$account) {
-		err "$rc_file: no \"github_account\" specified.\n";
-	}
-	
-    my $ctx = init_installation_ctx(0);
+    # we need the account info
+    my ($rc_file, $rc_data) = get_rc_file();
+    my $account = $rc_data->{default}->{github_account};
+    if (!$account) {
+        err "$rc_file: no \"github_account\" specified.\n";
+    }
 
-	# is it installed?
-	my $meta_file = File::Spec->catfile($ctx->{manifest_dir}, "$dist_name.meta");
+    my $ctx = init_installation_ctx(0);  # 0 = do not `$upgrade`
+
+    # is it installed?
+    my $meta_file = File::Spec->catfile($ctx->{manifest_dir}, "$dist_name.meta");
     my $remove_old;
     if (-f $meta_file) {
+    	# for `build-install`:
+    	#     *always* `remove_old` if the `meta_file` exists, regardless of version
+    	#     however, `get` will still need to compare version numbers
     	$remove_old = 1;
-	}
+    }
 
-
+	# package_ctx is needed to get the directories right for `install_distribution` 
     my $package_ctx_args = {
-    	"manifest_dir" => $ctx->{manifest_dir},
-    	"working_dir" => getcwd(),
-    	"account" => $account,
-    	"name" => $dist_name,
-    	"remove_old" => $remove_old,
+        "manifest_dir" => $ctx->{manifest_dir},
+        "working_dir" => getcwd(),
+        "account" => $account,
+        "name" => $dist_name,
+        "remove_old" => $remove_old,
     };
     my $package_ctx = init_package_ctx($package_ctx_args);
     install_distribution($ctx, $package_ctx, $versioned_file);
@@ -1439,14 +1441,14 @@ sub install_target ($$) {
         shell "rm -rf '$dist_dir'";
     }
 
-	my $package_ctx_args = {
-		"working_dir" => $cache_dir,
-		"cwd" => $cwd,
-		"manifest_dir" => $manifest_dir,
-		"account" => $account,
-		"name" => $name,
-		"remove_old" => $remove_old,
-	};
+    my $package_ctx_args = {
+        "working_dir" => $cache_dir,
+        "cwd" => $cwd,
+        "manifest_dir" => $manifest_dir,
+        "account" => $account,
+        "name" => $name,
+        "remove_old" => $remove_old,
+    };
     my $package_ctx = init_package_ctx($package_ctx_args);
     install_distribution($ctx, $package_ctx, $dist_file, );
     return;
@@ -1458,18 +1460,20 @@ SKIP_INSTALL:
 }
 
 
-sub install_distribution($$$){
-=pod
-installs a distribution file (.tar.gz)
+=begin comment
+`install_distribution`
+This installs a distribution file (.tar.gz)
+=end comment
 =cut
-	my ($ctx, $package_ctx, $distribution_file) = @_;
-	my $working_dir = $package_ctx->{working_dir};
-	my $account = $package_ctx->{account};
-	my $name = $package_ctx->{name};
+sub install_distribution($$$) {
+    my ($ctx, $package_ctx, $distribution_file) = @_;
+    my $working_dir = $package_ctx->{working_dir};
+    my $account = $package_ctx->{account};
+    my $name = $package_ctx->{name};
 
-	if (!-e $distribution_file){
-		err "the distribution was not found"
-	}
+    if (!-e $distribution_file){
+        err "the distribution was not found"
+    }
 
     (my $dist_dir = $distribution_file) =~ s/\.tar\.gz$//;
 
@@ -1876,7 +1880,7 @@ sub do_remove {
 
     my $deps = parse_deps(\@_, "(command-line argument)", 1);
 
-    my $ctx = init_installation_ctx(0);
+    my $ctx = init_installation_ctx(0);  # 0 = do not `$upgrade`
 
     for my $dep (@$deps) {
         my ($account, $name, $op, $ver) = @$dep;
@@ -2010,7 +2014,7 @@ sub do_upgrade {
         err "no packages specified for upgrade.\n";
     }
 
-    my $ctx = init_installation_ctx(1);
+    my $ctx = init_installation_ctx(1);  # 1 = `$upgrade`
     my $manifest_dir = $ctx->{manifest_dir};
 
     local $_;
@@ -2032,26 +2036,28 @@ sub do_upgrade {
     }
 }
 
-sub init_package_ctx ($){
-=pod
-The `package_ctx` is a scoped context object.
-It is used in parallel to the `installation_ctx`.
-=cut
-	my $defaults = shift;
-	my $package_ctx = {
-		cwd => $defaults->{cwd} // cwd,
-		getcwd => $defaults->{getcwd} // getcwd(),
-		working_dir => $defaults->{working_dir} // undef,  # install_target,
-		manifest_dir => $defaults->{manifest_dir} // undef,  # install_target, do_build_install
-		account => $defaults->{account} // undef,  # install_target, do_build_install
-		name => $defaults->{name} // undef,  # install_target
-		remove_old => $defaults->{remove_old} // undef,  # install_target
-	};
-	return $package_ctx;
+sub init_package_ctx ($) {
+	# The `package_ctx` is a scoped context object.
+	# It is used in parallel to the `installation_ctx`.
+	# * `working_dir` should be the cache_dir (get) or the local dir (build-install)
+    my $defaults = shift;
+    my $package_ctx = {
+        cwd => $defaults->{cwd} // cwd,
+        getcwd => $defaults->{getcwd} // getcwd(),
+        working_dir => $defaults->{working_dir} // undef,  # install_target,
+        manifest_dir => $defaults->{manifest_dir} // undef,  # install_target, do_build_install
+        account => $defaults->{account} // undef,  # install_target, do_build_install
+        name => $defaults->{name} // undef,  # install_target
+        remove_old => $defaults->{remove_old} // undef,  # install_target
+    };
+    return $package_ctx;
 }
 
 
 sub init_installation_ctx ($) {
+	# Core installation context
+	# Single argument is boolean `$upgrade`
+	
     my $upgrade = shift;
 
     my ($rc_file, $rc_data) = get_rc_file();
@@ -2172,7 +2178,7 @@ sub do_update {
         return;
     }
 
-    my $ctx = init_installation_ctx(1);
+    my $ctx = init_installation_ctx(1);  # 1 = `$upgrade`
 
     opendir my $dh, $manifest_dir
         or err "failed to open directory $manifest_dir: $!\n";
@@ -2461,7 +2467,9 @@ Commands:
                         for uploading to the server.
 
     build-install       Build from the current working directory a package tarball ready
-                        for uploading to the server, and install locally.
+                        for uploading to the server, verify the build with `server-build`,
+                        and finally install the package locally -- all without
+                        communicating with the server.
 
     clean ARGUMENT...   Do clean-up work. Currently the valid argument is "dist", which
                         cleans up the temporary files and directories created by the "build"

--- a/bin/opm
+++ b/bin/opm
@@ -182,10 +182,13 @@ sub do_get {
 
 
 =begin comment
-	`do_build($)`
-	The first argument indicates the build type should be a server build
-	`$is_server_build` should just be a "truthy" value (1 vs 0)
+
+    `do_build($)`
+    The first argument indicates the build type should be a server build
+    `$is_server_build` should just be a "truthy" value (1 vs 0)
+
 =end comment
+
 =cut
 
 sub do_build ($) {
@@ -677,10 +680,12 @@ _EOC_
     #}
 
     warn "build successful: '$TarBall'\n";
+
 }
 
 
 =begin comment
+
 `do_build_install()`
 This builds the currently authored package, then installs it locally (without
 communicated with the opm server).
@@ -690,9 +695,16 @@ It performs these functions:
     cd $dist_name-$version/
     opm server-build
     install $dist_name-$version.opm.tar.gz  # psuedocode
+
 =end comment
+
 =cut
+
 sub do_build_install () {
+
+	# note the directory we started in before we `chdir` anywhere
+    my $start_dir = cwd();
+
     # phase 1 - `opm build`
     do_build(0);  # 0 = normal
 
@@ -706,7 +718,8 @@ sub do_build_install () {
 
     # phase 2b - `cd `
     my $versioned_directory = "$dist_name-$version";
-    chdir $versioned_directory;
+    chdir $versioned_directory
+        or err "could not chdir to `$versioned_directory`\n";
 
     # phase 3 - `opm server-build`
     shell "opm server-build";
@@ -731,21 +744,23 @@ sub do_build_install () {
     my $meta_file = File::Spec->catfile($ctx->{manifest_dir}, "$dist_name.meta");
     my $remove_old;
     if (-f $meta_file) {
-    	# for `build-install`:
-    	#     *always* `remove_old` if the `meta_file` exists, regardless of version
-    	#     however, `get` will still need to compare version numbers
-    	$remove_old = 1;
+        # for `build-install`:
+        #     *always* `remove_old` if the `meta_file` exists, regardless of version
+        #     however, `get` will still need to compare version numbers
+        $remove_old = 1;
     }
 
-	# package_ctx is needed to get the directories right for `install_distribution` 
+    # package_ctx is needed to get the directories right for `install_distribution`
     my $package_ctx_args = {
         "manifest_dir" => $ctx->{manifest_dir},
         "working_dir" => getcwd(),
+        "start_dir" => $start_dir,
         "account" => $account,
         "name" => $dist_name,
         "remove_old" => $remove_old,
     };
     my $package_ctx = init_package_ctx($package_ctx_args);
+
     install_distribution($ctx, $package_ctx, $versioned_file);
 }
 
@@ -1414,7 +1429,9 @@ sub install_target ($$) {
         err "$dist_file_path not found.\n";
     }
 
-    my $cwd = cwd;
+	# note the directory we started in before we `chdir` anywhere
+	my $start_dir = cwd();
+
     chdir $cache_subdir
         or err "cannot chdir to $cache_subdir: $!\n";
 
@@ -1443,7 +1460,7 @@ sub install_target ($$) {
 
     my $package_ctx_args = {
         "working_dir" => $cache_dir,
-        "cwd" => $cwd,
+        "start_dir" => $start_dir,
         "manifest_dir" => $manifest_dir,
         "account" => $account,
         "name" => $name,
@@ -1461,11 +1478,15 @@ SKIP_INSTALL:
 
 
 =begin comment
+
 `install_distribution`
 This installs a distribution file (.tar.gz)
+
 =end comment
+
 =cut
-sub install_distribution($$$) {
+
+sub install_distribution ($$$) {
     my ($ctx, $package_ctx, $distribution_file) = @_;
     my $working_dir = $package_ctx->{working_dir};
     my $account = $package_ctx->{account};
@@ -1485,6 +1506,8 @@ sub install_distribution($$$) {
 
     chdir $dist_dir
         or err "cannot chdir to $working_dir/$dist_dir: $!\n";
+
+    my $dist_dir_full = getcwd();
 
     # read dist.ini
 
@@ -1573,16 +1596,16 @@ sub install_distribution($$$) {
 
     for my $spec (@lua_files) {
         my ($src, $dst) = @$spec;
-
-        install_file($src, $dst, $lualib_dir);
+        my $src_path = File::Spec->catfile($dist_dir_full, $src);
+        install_file($src_path, $dst, $lualib_dir);
     }
 
     my $pod_dir = $ctx->{pod_dir} or die;
 
     for my $spec (@pod_files) {
         my ($src, $dst) = @$spec;
-
-        install_file($src, $dst, $pod_dir);
+        my $src_path = File::Spec->catfile($dist_dir_full, $src);
+        install_file($src_path, $dst, $pod_dir);
     }
 
     my $list_file = File::Spec->catfile($package_ctx->{manifest_dir}, "$name.list");
@@ -1605,10 +1628,10 @@ sub install_distribution($$$) {
         close $out;
     }
 
-    install_file($ini_file, "$name.meta", $package_ctx->{manifest_dir});
+    my $src_path = File::Spec->catfile($dist_dir_full, $ini_file);
+    install_file($src_path, "$name.meta", $package_ctx->{manifest_dir});
 
     # install resty.index
-
     my $installed_restydoc_index = File::Spec->catfile($install_dir, "resty.index");
 
     {
@@ -1634,8 +1657,8 @@ sub install_distribution($$$) {
     warn "Package $account/$name $version installed successfully ",
          "under $install_dir/ .\n";
 
-    chdir $package_ctx->{cwd}
-        or err "cannot chdir to " . $package_ctx->{cwd} . ": $!\n";
+    chdir $package_ctx->{start_dir}
+        or err "cannot chdir to " . $package_ctx->{start_dir} . ": $!\n";
 
     return;
 }
@@ -1735,14 +1758,15 @@ sub cmp_version ($$) {
 sub remove_target ($$$) {
     my ($ctx, $name, $account) = @_;
 
+	# note the directory we started in before we `chdir` anywhere
+    my $start_dir = cwd();
+
     my $install_dir = $ctx->{install_dir};
     if (!defined $install_dir) {
         err "cannot find OpenResty system installation directory.\n";
     }
 
     #warn $install_dir;
-
-    my $cwd = cwd;
     chdir $install_dir or err "cannot chdir to $install_dir: $!\n";
 
     my $manifest_dir = "manifest";
@@ -1870,7 +1894,7 @@ sub remove_target ($$$) {
 
     warn "Package $account/$name $version removed successfully.\n";
 
-    chdir $cwd or err "cannot chdir to $install_dir";
+    chdir $start_dir or err "cannot chdir back to start: $start_dir";
 }
 
 sub do_remove {
@@ -2037,13 +2061,13 @@ sub do_upgrade {
 }
 
 sub init_package_ctx ($) {
-	# The `package_ctx` is a scoped context object.
-	# It is used in parallel to the `installation_ctx`.
-	# * `working_dir` should be the cache_dir (get) or the local dir (build-install)
+    # The `package_ctx` is a scoped context object.
+    # It is used in parallel to the `installation_ctx`.
+    # * `working_dir` should be the cache_dir (get) or the local dir (build-install)
     my $defaults = shift;
     my $package_ctx = {
-        cwd => $defaults->{cwd} // cwd,
         getcwd => $defaults->{getcwd} // getcwd(),
+        start_dir => $defaults->{start_dir} // undef,  # used throughout
         working_dir => $defaults->{working_dir} // undef,  # install_target,
         manifest_dir => $defaults->{manifest_dir} // undef,  # install_target, do_build_install
         account => $defaults->{account} // undef,  # install_target, do_build_install
@@ -2055,9 +2079,9 @@ sub init_package_ctx ($) {
 
 
 sub init_installation_ctx ($) {
-	# Core installation context
-	# Single argument is boolean `$upgrade`
-	
+    # Core installation context
+    # Single argument is boolean `$upgrade`
+
     my $upgrade = shift;
 
     my ($rc_file, $rc_data) = get_rc_file();

--- a/bin/opm
+++ b/bin/opm
@@ -17,7 +17,7 @@ use Digest::MD5 ();
 use File::Copy qw( copy move );
 use File::Temp qw( tempfile );
 use Getopt::Long qw( GetOptions :config no_ignore_case require_order);
-# use Data::Dumper qw( Dumper );
+#use Data::Dumper qw( Dumper );
 
 my $MAX_DEPS = 100;
 my $Version = '0.0.1';

--- a/bin/opm
+++ b/bin/opm
@@ -12,12 +12,12 @@ use File::Find ();
 use File::Path qw( make_path );
 use File::Spec ();
 use Config ();
-use Cwd qw( realpath cwd );
+use Cwd qw( realpath cwd getcwd );
 use Digest::MD5 ();
 use File::Copy qw( copy move );
 use File::Temp qw( tempfile );
 use Getopt::Long qw( GetOptions :config no_ignore_case require_order);
-#use Data::Dumper qw( Dumper );
+# use Data::Dumper qw( Dumper );
 
 my $MAX_DEPS = 100;
 my $Version = '0.0.1';
@@ -58,15 +58,18 @@ sub is_valid_dist_name ($$);
 sub find_sys_install_dir ();
 sub get_install_dir ();
 sub install_file ($$$);
+sub install_distribution ($$$);
 sub install_target ($$);
 sub upgrade_target ($$$$);
 sub remove_target ($$$);
 sub do_build ($);
+sub do_build_install ();
 sub check_lock_file ();
 sub get_rc_file ();
 sub create_stub_rc_file ($);
 sub read_ini ($);
 sub init_installation_ctx ($);
+sub init_package_ctx ($);
 sub cmp_version ($$);
 sub search_pkg_name ($$);
 sub test_version_spec ($$$$$);
@@ -101,6 +104,7 @@ if ($cmd eq '-v') {
 delete $ENV{LUA_PATH};
 delete $ENV{LUA_CPATH};
 
+# main command handling block
 for ($cmd) {
     if ($_ eq 'get' || $_ eq 'install') {
         check_lock_file();
@@ -108,15 +112,18 @@ for ($cmd) {
         do_get(@ARGV);
 
     } elsif ($_ eq 'build') {
-        do_build(0);
+        do_build(0);  # 0 = normal build
 
     } elsif ($_ eq 'server-build') {
-        do_build(1);
+        do_build(1);  # 1 = server-build
+
+    } elsif ($_ eq 'build-install') {
+        do_build_install();
 
     } elsif ($_ eq 'upload') {
         check_lock_file();
 
-        do_build(0);
+        do_build(0);  # 0 = normal build
         do_upload();
 
     } elsif ($_ eq 'remove' || $_ eq 'uninstall') {
@@ -174,7 +181,14 @@ sub do_get {
 }
 
 sub do_build ($) {
-    my $server_build = shift;
+=pod
+`do_build($)`
+The first argument indicates the build type
+	0 = build
+	1 = server-build
+=cut
+    my $_build_type = shift;
+    my $server_build = ($_build_type == 1) ? 1 : 0;
 
     #if ($server_build) { while (1) {} }
 
@@ -662,6 +676,75 @@ _EOC_
     #if ($server_build) {
     #err "something bad bad bad.\n";
     #}
+
+    warn "build successful: '$TarBall'\n";
+}
+
+sub do_build_install () {
+=pod
+`do_build_install()`
+This builds the currently authored package, then installs it locally (without 
+communicated with the opm server).
+
+It performs these functions:
+
+	opm build
+	cd $dist_name-$version/
+	opm server-build
+	install $dist_name-$version.opm.tar.gz  # psuedocode
+=cut
+
+	# phase 1 - `opm build`
+	do_build(0);  # 0 = normal
+
+	# phase 2 - `cd $dist_name-$version/`
+	# phase 2a - derive the version data	
+    my $dist_file = "dist.ini";
+    my $data = read_ini($dist_file);
+    my $default_sec = $data->{default};
+    my $dist_name = $default_sec->{name};
+    my $version = $default_sec->{version};
+
+	# phase 2b - `cd `
+	my $versioned_directory = "$dist_name-$version";
+	chdir $versioned_directory;
+
+	# phase 3 - `opm server-build`
+	shell "opm server-build";
+
+	# phase 4 - `install $dist_name-$version.opm.tar.gz`
+	# we're down a directory, go back up
+	# actually, don't.  the opm.gz file is what we want to install here
+	# chdir File::Spec->updir;
+
+	my $versioned_file = "$dist_name-$version.opm.tar.gz";
+
+	# we need the account info
+	my ($rc_file, $rc_data) = get_rc_file();
+	my $account = $rc_data->{default}->{github_account};
+	if (!$account) {
+		err "$rc_file: no \"github_account\" specified.\n";
+	}
+	
+    my $ctx = init_installation_ctx(0);
+
+	# is it installed?
+	my $meta_file = File::Spec->catfile($ctx->{manifest_dir}, "$dist_name.meta");
+    my $remove_old;
+    if (-f $meta_file) {
+    	$remove_old = 1;
+	}
+
+
+    my $package_ctx_args = {
+    	"manifest_dir" => $ctx->{manifest_dir},
+    	"working_dir" => getcwd(),
+    	"account" => $account,
+    	"name" => $dist_name,
+    	"remove_old" => $remove_old,
+    };
+    my $package_ctx = init_package_ctx($package_ctx_args);
+    install_distribution($ctx, $package_ctx, $versioned_file);
 }
 
 sub read_ini ($) {
@@ -1356,14 +1439,48 @@ sub install_target ($$) {
         shell "rm -rf '$dist_dir'";
     }
 
-    shell "tar -oxzf '$dist_file'";
+	my $package_ctx_args = {
+		"working_dir" => $cache_dir,
+		"cwd" => $cwd,
+		"manifest_dir" => $manifest_dir,
+		"account" => $account,
+		"name" => $name,
+		"remove_old" => $remove_old,
+	};
+    my $package_ctx = init_package_ctx($package_ctx_args);
+    install_distribution($ctx, $package_ctx, $dist_file, );
+    return;
+
+SKIP_INSTALL:
+
+    warn "Package $name-$installed_ver already installed.\n";
+    return;
+}
+
+
+sub install_distribution($$$){
+=pod
+installs a distribution file (.tar.gz)
+=cut
+	my ($ctx, $package_ctx, $distribution_file) = @_;
+	my $working_dir = $package_ctx->{working_dir};
+	my $account = $package_ctx->{account};
+	my $name = $package_ctx->{name};
+
+	if (!-e $distribution_file){
+		err "the distribution was not found"
+	}
+
+    (my $dist_dir = $distribution_file) =~ s/\.tar\.gz$//;
+
+    shell "tar -oxzf '$distribution_file'";
 
     if (!-d $dist_dir) {
-        err "the unpacked directory $dist_dir not found under $cache_subdir.\n";
+        err "the unpacked directory $dist_dir not found under $working_dir.\n";
     }
 
     chdir $dist_dir
-        or err "cannot chdir to $cache_subdir/$dist_dir: $!\n";
+        or err "cannot chdir to $working_dir/$dist_dir: $!\n";
 
     # read dist.ini
 
@@ -1417,7 +1534,7 @@ sub install_target ($$) {
         err "no library files found in $dist_dir/.\n";
     }
 
-    if ($remove_old) {
+    if ($package_ctx->{remove_old}) {
         remove_target($ctx, $name, undef);
     }
 
@@ -1464,7 +1581,7 @@ sub install_target ($$) {
         install_file($src, $dst, $pod_dir);
     }
 
-    my $list_file = File::Spec->catfile($manifest_dir, "$name.list");
+    my $list_file = File::Spec->catfile($package_ctx->{manifest_dir}, "$name.list");
 
     {
         open my $out, ">$list_file"
@@ -1484,7 +1601,7 @@ sub install_target ($$) {
         close $out;
     }
 
-    install_file($ini_file, "$name.meta", $manifest_dir);
+    install_file($ini_file, "$name.meta", $package_ctx->{manifest_dir});
 
     # install resty.index
 
@@ -1513,14 +1630,9 @@ sub install_target ($$) {
     warn "Package $account/$name $version installed successfully ",
          "under $install_dir/ .\n";
 
-    chdir $cwd
-        or err "cannot chdir to $cwd: $!\n";
+    chdir $package_ctx->{cwd}
+        or err "cannot chdir to " . $package_ctx->{cwd} . ": $!\n";
 
-    return;
-
-SKIP_INSTALL:
-
-    warn "Package $name-$installed_ver already installed.\n";
     return;
 }
 
@@ -1919,6 +2031,25 @@ sub do_upgrade {
         upgrade_target($ctx, $account, $name, $meta_file);
     }
 }
+
+sub init_package_ctx ($){
+=pod
+The `package_ctx` is a scoped context object.
+It is used in parallel to the `installation_ctx`.
+=cut
+	my $defaults = shift;
+	my $package_ctx = {
+		cwd => $defaults->{cwd} // cwd,
+		getcwd => $defaults->{getcwd} // getcwd(),
+		working_dir => $defaults->{working_dir} // undef,  # install_target,
+		manifest_dir => $defaults->{manifest_dir} // undef,  # install_target, do_build_install
+		account => $defaults->{account} // undef,  # install_target, do_build_install
+		name => $defaults->{name} // undef,  # install_target
+		remove_old => $defaults->{remove_old} // undef,  # install_target
+	};
+	return $package_ctx;
+}
+
 
 sub init_installation_ctx ($) {
     my $upgrade = shift;
@@ -2328,6 +2459,9 @@ Options:
 Commands:
     build               Build from the current working directory a package tarball ready
                         for uploading to the server.
+
+    build-install       Build from the current working directory a package tarball ready
+                        for uploading to the server, and install locally.
 
     clean ARGUMENT...   Do clean-up work. Currently the valid argument is "dist", which
                         cleans up the temporary files and directories created by the "build"


### PR DESCRIPTION
This is my first attempt at handling https://github.com/openresty/opm/issues/39  

I haven't touched Perl in years so apologies in advance.

It seems to work, but there aren't any tests to plug into.  I documented new functions inline, and also added docs for existing functions too.

Notes: 

* The command is invoked as `opm build-install` as it wraps the build process and installs locally (as requested)

* A new core subroutine of `do_build_install` was created, which handles most of the overall logic

* build-install will always remove an existing version, it will not compare revisions. 

* Variable names were standardized for easier maintenance:

   * `$rcfile` -> `$rc_file` (same style as `$ini_file`)
   * `$data` -> `$rc_data`, `$ini_data`
   * `$default_sec` -> `$rc_default_sec`, `$ini_default_sec`

* I noted what the arguments meant to various subroutines, both when invoked and in the subroutine iteself

I tried to leverage existing code, and am not thrilled with my approach (but it does work)

* `install_target` was dropped into two routines: `install_target` and `install_distribution`.  
* `install_distribution` handles installing the actual distribution file.  Most metadata is calculated in `install_target` or `do_build_install`
* in order to keep track of some package and directory data, I created a secondary context object with `init_package_ctx`.  It's used alongside the existing `init_installation_ctx`, but is limited to the current package info, and mostly used for specifying the cache directory vs the current directory.



