### PR TITLE
bugfix: opm get: curl via HTTP proxies will complain about "bad response status line received"

### DIFF
--- a/bin/opm
+++ b/bin/opm
@@ -2302,7 +2302,7 @@ sub trim_curl_out ($) {
     my $s = shift;
 
     if (defined $s) {
-        $s =~ s{\AHTTP/\d+(?:\.\d+)? 200 Connection established\r\n.*?\r\n\r\n}{}msi;
+        $s =~ s{\AHTTP/\d+(?:\.\d+)? 200 Connection established.*?\r\n\r\n}{}msi;
     }
 
     $s;


### PR DESCRIPTION
### Reproduce steps
1. set environment `http_proxy`/`https_proxy` to your proxy uri.
2. `opm get openresty/lua-resty-limit-traffic`  gets error message:
```
* Fetching openresty/lua-resty-limit-traffic  
ERROR: bad response status line received from server for URL "https://opm.openresty.org/api/pkg/fetch?account=openresty&name=lua-resty-limit-traffic&op=&version=": <html>
```

### Root cause
function `trim_curl_out` failed when proxy's response contains only status-line.

### Details

Line 1191 in bin/opm:
```perl
    my $cmd = qq/curl -sS -i -A '$UserAgent' '$url'/;
    my $out = `$cmd`;
    $out = trim_curl_out $out;
```

curl cmd get response:
```
HTTP/1.1 200 Connection established

HTTP/1.1 302 Moved Temporarily
Server: openresty+
Date: Thu, 31 Aug 2017 07:11:37 GMT
Content-Type: text/html
Content-Length: 154
Connection: keep-alive
X-File-Checksum: b8d324d8-d66e-bb74-43ca-7e01796fa930
Location: /api/pkg/tarball/openresty/lua-resty-lrucache-0.07.opm.tar.gz
Expires: Thu, 31 Aug 2017 07:12:44 GMT
Cache-Control: max-age=180
Cache-Status: HIT
Cache-Status: MISS

<html>
<head><title>302 Found</title></head>
<body bgcolor="white">
<center><h1>302 Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

Then `trim_curl_out` will fail when trimming proxy headers out by regex:

```
 $s =~ s{\AHTTP/\d+(?:\.\d+)? 200 Connection established\r\n.*?\r\n\r\n}{}msi;
```
