### PR TITLE
opm: revamp options

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ Usage
 opm [options] command package...
 
 Options:
-    -h
-    --help              Print this help.
+    -h, --help          Print this help.
 
+    -V, --version       Print opm version and exit.
+
+    -v, --verbose       Display verbose output.
 
     --install-dir=PATH  Install into the specified PATH directory instead of the system-wide
                         OpenResty installation tree containing this tool.
@@ -933,4 +935,3 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [Back to TOC](#table-of-contents)
-

--- a/bin/opm
+++ b/bin/opm
@@ -16,7 +16,7 @@ use Cwd qw( realpath cwd );
 use Digest::MD5 ();
 use File::Copy qw( copy move );
 use File::Temp qw( tempfile );
-use Getopt::Long qw( GetOptions :config no_ignore_case require_order);
+use Getopt::Long qw( GetOptions :config no_ignore_case no_auto_abbrev require_order );
 #use Data::Dumper qw( Dumper );
 
 my $MAX_DEPS = 100;
@@ -76,13 +76,19 @@ sub rebase_path ($$$);
 sub trim_curl_out ($);
 
 GetOptions("h|help",          \(my $help),
+           "V|version",       \(my $print_version),
            "cwd",             \(my $install_into_cwd),
            "install-dir=s",   \(my $user_install_dir),
-           "verbose",         \(my $verbose))
-   or usage(1);
+           "v|verbose",       \(my $verbose))
+    or usage(1);
 
 if ($help) {
     usage(0);
+}
+
+if ($print_version) {
+    print "opm $Version ($Config::Config{archname}, perl $^V)\n";
+    exit;
 }
 
 if (defined $user_install_dir && defined $install_into_cwd) {
@@ -90,11 +96,6 @@ if (defined $user_install_dir && defined $install_into_cwd) {
 }
 
 my $cmd = shift or usage(1);
-
-if ($cmd eq '-v') {
-    print "opm $Version ($Config::Config{archname}, perl $^V)\n";
-    exit;
-}
 
 # explicitly clear the environments to avoid breaking luajit and resty.
 delete $ENV{LUA_PATH};
@@ -2317,8 +2318,11 @@ sub usage {
 opm [options] command package...
 
 Options:
-    -h
-    --help              Print this help.
+    -h, --help          Print this help.
+
+    -V, --version       Print opm version and exit.
+
+    -v, --verbose       Display verbose output.
 
     --install-dir=PATH  Install into the specified PATH directory instead of the system-wide
                         OpenResty installation tree containing this tool.


### PR DESCRIPTION
* document verbose option
* fix and document version option
* disable auto abbreviation

[`auto_abbrev`](https://perldoc.perl.org/5.10.1/Getopt::Long#auto_abbrev) was the reason `-v` (version option) didn't work as intended; it was treated as an abbreviated `--verbose` option. Since abbreviated options (e.g., `--cmd` → `-c`, `--install-dir` → `-i`) hadn't been documented, it's safe to disable this feature. However, `--verbose` → `-v` abbreviation is so ubiquitous that it's worth allowing explicitly. For the same reason, `--version` is abbreviated to `-V`.